### PR TITLE
Fix XSS in FormHandler.js showMessages method

### DIFF
--- a/src/public/FormHandler.js
+++ b/src/public/FormHandler.js
@@ -736,22 +736,28 @@ class PayFormHandler {
         this.buttonState('normal', '', false);
     }
 
+    escapeHtml(str) {
+        const div = document.createElement('div');
+        div.appendChild(document.createTextNode(str));
+        return div.innerHTML;
+    }
+
     showMessages(messages, type, heading) {
         this.resetMessages();
 
         let html = '';
         if (heading) {
-            html += '<p class="wpf_alert_heading">' + heading + '</p>';
+            html += '<p class="wpf_alert_heading">' + this.escapeHtml(heading) + '</p>';
         }
 
         if (typeof messages == 'string' && messages) {
-            html += messages;
+            html += this.escapeHtml(messages);
         }
 
         if (typeof messages == 'object' && messages) {
             html += '<ul class="wpf_alert_ietms">';
             jQuery.each(messages, (index, message) => {
-                html += '<li>' + message + '</li>';
+                html += '<li>' + this.escapeHtml(message) + '</li>';
             });
             html += '</ul>';
         }


### PR DESCRIPTION
## Summary

- Adds `escapeHtml()` method to safely escape HTML metacharacters
- Escapes `heading`, `message` (string), and `message` (object iteration) values before inserting into DOM in `showMessages()`
- Prevents potential cross-site scripting via form notice content

## Details

`src/public/FormHandler.js` inserts `heading` and `message` values directly into HTML without escaping. If these contain HTML metacharacters (e.g. `<script>` tags), they are interpreted as HTML — a DOM-based XSS vulnerability.

Identified by GitHub CodeQL (rule: DOM text reinterpreted as HTML, severity: high).

Fixes #35